### PR TITLE
Do not expose `bun` CLI to the end user

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 
 
 [Bun](https://bun.sh/) is an all-in-one toolkit for JavaScript and TypeScript apps.
+
 The [pybun](https://pypi.org/project/pybun/) Python package redistributes the Bun executable so that it can be used as a dependency in your Python projects.
 
 

--- a/README.md
+++ b/README.md
@@ -4,21 +4,25 @@
 
 
 [Bun](https://bun.sh/) is an all-in-one toolkit for JavaScript and TypeScript apps.
-The [pybun](https://pypi.org/project/pybun/) Python package redistributes the Bun CLI executable so that it can be used as a dependency in your Python projects.
+The [pybun](https://pypi.org/project/pybun/) Python package redistributes the Bun executable so that it can be used as a dependency in your Python projects.
 
 
 Usage
 -----
 
-To run the Bun CLI from the command line, you can use:
+### Command line
 
 ```shell
 pybun --version
-bun --version
+```
+
+### Run library module as a script
+
+```shell
 python -m pybun --version
 ```
 
-To run the Bun CLI from a Python program, use `sys.executable` to locate the Python binary to invoke. For example:
+### From python
 
 ```python
 import sys, subprocess

--- a/assets/entry_points.txt
+++ b/assets/entry_points.txt
@@ -1,3 +1,2 @@
 [console_scripts]
-bun = pybun.__main__:main
 pybun = pybun.__main__:main


### PR DESCRIPTION
We silently expose a CLI to the bun executable on the user's PATH which could mess with its own existing bun setup.

Instead, pybun now only exposes a CLI to the bun executable via `pybun`, `python -m pybun`, or a programmatic access.

Fix #2
